### PR TITLE
Add entry tests

### DIFF
--- a/lib/candy_xml.ex
+++ b/lib/candy_xml.ex
@@ -1,7 +1,55 @@
 defmodule CandyXml do
   import SweetXml
 
-  def parse!(xml) do
-    # pass an xml to this which returns structs
+  defstruct [:title, :link, :summary, :updated_date, :rss_feed_id, :cik_id]
+
+  def parse(xml) do
+    %CandyXml{
+      title: parse_title(xml),
+      link: parse_link(xml),
+      summary: parse_summary(xml),
+      updated_date: parse_updated_date(xml),
+      rss_feed_id: parse_rss_feed_id(xml),
+      cik_id: parse_cik_id(xml)
+    }
+  end
+
+  defp parse_title(xml) do
+    xml
+    |> xpath(~x"./title/text()"s)
+  end
+
+  defp parse_link(xml) do
+    xml
+    |> xpath(~x"./link/text()"s)
+  end
+
+  defp parse_summary(xml) do
+    xml
+    |> xpath(~x"./summary/text()"s)
+  end
+
+  defp parse_updated_date(xml) do
+    xml
+    |> xpath(~x"./updated/text()"s)
+  end
+
+  defp parse_rss_feed_id(xml) do
+    xml
+    |> xpath(~x"./id/text()"s)
+  end
+
+  defp parse_cik_id(xml) do
+    regex = ~r/\(\d+\)/
+    title = xml
+    |> xpath(~x"./title/text()"s)
+
+    Regex.run(regex, title, capture: :first)
+    |> hd
+    |> String.split("(")
+    |> tl
+    |> hd
+    |> String.split(")")
+    |> hd
   end
 end

--- a/lib/candy_xml.ex
+++ b/lib/candy_xml.ex
@@ -20,13 +20,19 @@ defmodule CandyXml do
   end
 
   defp parse_link(xml) do
-    xml
-    |> xpath(~x"./link/text()"s)
+    link_prefix = xml
+    |> String.split("href=\"")
+    |> tl
+    |> hd
+    |> String.split(".htm")
+    |> hd
+    link_prefix <> ".htm"
   end
 
   defp parse_summary(xml) do
     xml
     |> xpath(~x"./summary/text()"s)
+    |> String.strip
   end
 
   defp parse_updated_date(xml) do

--- a/test/candy_xml_test.exs
+++ b/test/candy_xml_test.exs
@@ -50,7 +50,7 @@ defmodule CandyXmlTest do
 
   test "parses summary" do
     entry = entry_xml |> parse
-    assert entry.summary == "&lt;b&gt;Filed:&lt;/b&gt; 2016-02-17 &lt;b&gt;AccNo:&lt;/b&gt; 0001615774-16-004243 &lt;b&gt;Size:&lt;/b&gt; 8 MB"
+    assert entry.summary == "<b>Filed:</b> 2016-02-17 <b>AccNo:</b> 0001615774-16-004243 <b>Size:</b> 8 MB"
   end
 
   test "parses title" do

--- a/test/candy_xml_test.exs
+++ b/test/candy_xml_test.exs
@@ -1,21 +1,27 @@
 defmodule CandyXmlTest do
   use ExUnit.Case
   doctest CandyXml
-
-  # https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type=10-K&company=&dateb=&owner=include&start=0&count=100&output=atom
-  # an <entry> has the following
-  # filing
-  # cik_id
-  # link
-  # rss_feed_id
-  # summary
-  # title
-  # updated_date
-
   import CandyXml
 
+  def entry_xml do
+    """
+    <entry>
+      <title>10-K - GARMIN LTD (0001121788) (Filer)</title>
+      <link rel="alternate" type="text/html" href="http://www.sec.gov/Archives/edgar/data/1121788/000161577416004243/0001615774-16-004243-index.htm"/>
+      <summary type="html">
+        &lt;b&gt;Filed:&lt;/b&gt; 2016-02-17 &lt;b&gt;AccNo:&lt;/b&gt; 0001615774-16-004243 &lt;b&gt;Size:&lt;/b&gt; 8 MB
+      </summary>
+      <updated>2016-02-17T17:24:49-05:00</updated>
+      <category scheme="http://www.sec.gov/" label="form type" term="10-K"/>
+      <id>urn:tag:sec.gov,2008:accession-number=0001615774-16-004243</id>
+    </entry>
+    """
+  end
+
+  # https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type=10-K&company=&dateb=&owner=include&start=0&count=100&output=atom
+
   test "parse!/1: parses RSS atom compliant XML" do
-    xml = File.read!("test/fixtures/filings_atom_feed.xml")
+    xml = Fiile.read!("test/fixtures/filings_atom_feed.xml")
     assert parse!(xml)
   end
 
@@ -24,31 +30,38 @@ defmodule CandyXmlTest do
     assert_raise RuntimeError, fn -> parse!(xml) end
   end
 
-  test "parses filing" do
-    # get the filing
+  test "has an entry" do
+    {:ok, feed} = File.read("test/fixtures/filings_atom_feed.xml") |> parse
+    assert feed.entry
   end
 
   test "parses cik_id" do
-    # get the cik_id
+    {:ok, feed} = entry_xml |> parse
+    assert.cik_id == '0001121788'
   end
 
   test "parses link" do
-    # get the link
+    {:ok, feed} = entry_xml |> parse
+    assert.link == "http://www.sec.gov/Archives/edgar/data/1121788/000161577416004243/0001615774-16-004243-index.htm"
   end
 
   test "parses rss_feed_id" do
-    # get the rss_feed_id
+    {:ok, feed} = entry_xml |> parse
+    assert.rss_feed_id = "urn:tag:sec.gov,2008:accession-number=0001615774-16-004243"
   end
 
   test "parses summary" do
-    # get the summary
+    {:ok, feed} = entry_xml |> parse
+    assert.summary = "&lt;b&gt;Filed:&lt;/b&gt; 2016-02-17 &lt;b&gt;AccNo:&lt;/b&gt; 0001615774-16-004243 &lt;b&gt;Size:&lt;/b&gt; 8 MB"
   end
 
   test "parses title" do
-    # get the title
+    {:ok, feed} = entry_xml |> parse
+    assert.title = "10-K - GARMIN LTD (0001121788) (Filer)"
   end
 
   test "parses updated_date" do
-    # get the updated_date
+    {:ok, feed} = entry_xml |> parse
+    assert.updated_date = "2016-02-17T17:24:49-05:00"
   end
 end

--- a/test/candy_xml_test.exs
+++ b/test/candy_xml_test.exs
@@ -1,6 +1,6 @@
 defmodule CandyXmlTest do
   use ExUnit.Case
-  doctest CandyXml
+
   import CandyXml
 
   def entry_xml do
@@ -18,50 +18,48 @@ defmodule CandyXmlTest do
     """
   end
 
-  # https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type=10-K&company=&dateb=&owner=include&start=0&count=100&output=atom
+  #test "parse!/1: parses RSS atom compliant XML" do
+    #xml = File.read!("test/fixtures/filings_atom_feed.xml")
+    #assert parse!(xml)
+  #end
 
-  test "parse!/1: parses RSS atom compliant XML" do
-    xml = Fiile.read!("test/fixtures/filings_atom_feed.xml")
-    assert parse!(xml)
-  end
+  #test "parse!/1: raises error on invalid XML" do
+    #xml = "naw"
+    #assert_raise RuntimeError, fn -> parse!(xml) end
+  #end
 
-  test "parse!/1: raises error on invalid XML" do
-    xml = "naw"
-    assert_raise RuntimeError, fn -> parse!(xml) end
-  end
-
-  test "has an entry" do
-    {:ok, feed} = File.read("test/fixtures/filings_atom_feed.xml") |> parse
-    assert feed.entry
-  end
+  #test "has an entry" do
+    #{:ok, feed} = File.read("test/fixtures/filings_atom_feed.xml") |> parse
+    #assert feed.entry
+  #end
 
   test "parses cik_id" do
-    {:ok, feed} = entry_xml |> parse
-    assert.cik_id == '0001121788'
+    entry = entry_xml |> parse
+    assert entry.cik_id == "0001121788"
   end
 
   test "parses link" do
-    {:ok, feed} = entry_xml |> parse
-    assert.link == "http://www.sec.gov/Archives/edgar/data/1121788/000161577416004243/0001615774-16-004243-index.htm"
+    entry = entry_xml |> parse
+    assert entry.link == "http://www.sec.gov/Archives/edgar/data/1121788/000161577416004243/0001615774-16-004243-index.htm"
   end
 
   test "parses rss_feed_id" do
-    {:ok, feed} = entry_xml |> parse
-    assert.rss_feed_id = "urn:tag:sec.gov,2008:accession-number=0001615774-16-004243"
+    entry = entry_xml |> parse
+    assert entry.rss_feed_id == "urn:tag:sec.gov,2008:accession-number=0001615774-16-004243"
   end
 
   test "parses summary" do
-    {:ok, feed} = entry_xml |> parse
-    assert.summary = "&lt;b&gt;Filed:&lt;/b&gt; 2016-02-17 &lt;b&gt;AccNo:&lt;/b&gt; 0001615774-16-004243 &lt;b&gt;Size:&lt;/b&gt; 8 MB"
+    entry = entry_xml |> parse
+    assert entry.summary == "&lt;b&gt;Filed:&lt;/b&gt; 2016-02-17 &lt;b&gt;AccNo:&lt;/b&gt; 0001615774-16-004243 &lt;b&gt;Size:&lt;/b&gt; 8 MB"
   end
 
   test "parses title" do
-    {:ok, feed} = entry_xml |> parse
-    assert.title = "10-K - GARMIN LTD (0001121788) (Filer)"
+    entry = entry_xml |> parse
+    assert entry.title == "10-K - GARMIN LTD (0001121788) (Filer)"
   end
 
   test "parses updated_date" do
-    {:ok, feed} = entry_xml |> parse
-    assert.updated_date = "2016-02-17T17:24:49-05:00"
+    entry = entry_xml |> parse
+    assert entry.updated_date == "2016-02-17T17:24:49-05:00"
   end
 end


### PR DESCRIPTION
This PR adds tests for checking that the parser parses an `entry` in the SEC feed correctly:

``` xml
<entry>
  <title>10-K - GARMIN LTD (0001121788) (Filer)</title>
  <link rel="alternate" type="text/html" href="http://www.sec.gov/Archives/edgar/data/1121788/000161577416004243/0001615774-16-004243-index.htm"/>
  <summary type="html">
    &lt;b&gt;Filed:&lt;/b&gt; 2016-02-17 &lt;b&gt;AccNo:&lt;/b&gt; 0001615774-16-004243 &lt;b&gt;Size:&lt;/b&gt; 8 MB
  </summary>
  <updated>2016-02-17T17:24:49-05:00</updated>
  <category scheme="http://www.sec.gov/" label="form type" term="10-K"/>
  <id>urn:tag:sec.gov,2008:accession-number=0001615774-16-004243</id>
</entry>
```
