### PR TITLE
Floki Refactor

### DIFF
--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -65,8 +65,7 @@ defmodule CandyXml.Entry do
 
   defp parse_cik_id(xml) do
     regex = ~r/\(\d+\)/
-    title = xml
-    |> xpath(~x"//entry/title/text()"s)
+    title = parse_title(xml)
 
     Regex.run(regex, title, capture: :first)
     |> hd

--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -39,9 +39,16 @@ defmodule CandyXml.Entry do
     |> String.strip
   end
 
+  defp extract_updated(tuple) do
+    {_, _, updated} = tuple
+    updated |> hd
+  end
+
   defp parse_updated_date(xml) do
     xml
-    |> xpath(~x"//entry/updated/text()"s)
+    |> Floki.find("updated")
+    |> hd
+    |> extract_updated
   end
 
   defp parse_rss_feed_id(xml) do

--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -39,7 +39,7 @@ defmodule CandyXml.Entry do
     |> String.strip
   end
 
-  defp extract_updated(tuple) do
+  defp extract_updated_date(tuple) do
     {_, _, updated} = tuple
     updated |> hd
   end
@@ -48,12 +48,19 @@ defmodule CandyXml.Entry do
     xml
     |> Floki.find("updated")
     |> hd
-    |> extract_updated
+    |> extract_updated_date
+  end
+
+  defp extract_rss_feed_id(tuple) do
+    {_, _, rss_feed_id} = tuple
+    rss_feed_id |> hd
   end
 
   defp parse_rss_feed_id(xml) do
     xml
-    |> xpath(~x"//entry/id/text()"s)
+    |> Floki.find("id")
+    |> hd
+    |> extract_rss_feed_id
   end
 
   defp parse_cik_id(xml) do

--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -14,9 +14,16 @@ defmodule CandyXml.Entry do
     }
   end
 
+  defp extract_title(tuple) do
+    {_, _, title} = tuple
+    title |> hd
+  end
+
   defp parse_title(xml) do
-    xml
-    |> xpath(~x"//entry/title/text()"s)
+    embedded = xml
+    |> Floki.find("title")
+    |> hd
+    |> extract_title
   end
 
   defp parse_link(xml) do

--- a/lib/feed.ex
+++ b/lib/feed.ex
@@ -15,8 +15,15 @@ defmodule CandyXml.Feed do
     |> Enum.map(fn entry -> CandyXml.Entry.parse(Floki.raw_html(entry)) end)
   end
 
+  defp extract_updated(tuple) do
+    {_, _, updated_date} = tuple
+    updated_date |> hd
+  end
+
   defp parse_updated(feed) do
     feed
-    |> xpath(~x"//feed/updated/text()"s)
+    |> Floki.find("updated")
+    |> hd
+    |> extract_updated
   end
 end


### PR DESCRIPTION
This PR removes the `sweet_xml` dependency for parsing XML Feeds and replaces it [Floki](https://github.com/philss/floki), which seems to be an easier library to implement for this specific use case.
