### PR TITLE
rename from CandyXml to SecLatestFilingsRssFeedParser

### DIFF
--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -1,4 +1,4 @@
-defmodule CandyXml.Entry do
+defmodule SecLatestFilingsRssFeedParser.Entry do
   import SweetXml
 
   defstruct [:title, :link, :summary, :updated_date, :rss_feed_id, :cik_id]

--- a/lib/feed.ex
+++ b/lib/feed.ex
@@ -1,4 +1,4 @@
-defmodule CandyXml.Feed do
+defmodule SecLatestFilingsRssFeedParser.Feed do
   import SweetXml
 
   defstruct [:entry]
@@ -12,7 +12,7 @@ defmodule CandyXml.Feed do
 
   defp parse_feed(xml) do
     Floki.find(xml, "entry")
-    |> Enum.map(fn entry -> CandyXml.Entry.parse(Floki.raw_html(entry)) end)
+    |> Enum.map(fn entry -> SecLatestFilingsRssFeedParser.Entry.parse(Floki.raw_html(entry)) end)
   end
 
   defp extract_updated(tuple) do

--- a/lib/sec_latest_filings_rss_feed_parser.ex
+++ b/lib/sec_latest_filings_rss_feed_parser.ex
@@ -1,6 +1,6 @@
-defmodule CandyXml do
+defmodule SecLatestFilingsRssFeedParser do
   def parse(xml) do
-    {:ok, CandyXml.Feed.parse(xml)}
+    {:ok, SecLatestFilingsRssFeedParser.Feed.parse(xml)}
   catch
     :exit, _ -> {:error, "expected element start tag"}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule CandyXml.Mixfile do
+defmodule SecLatestFilingsRssFeedParser.Mixfile do
   use Mix.Project
 
   def project do

--- a/test/candy_xml_test.exs
+++ b/test/candy_xml_test.exs
@@ -1,11 +1,11 @@
-defmodule CandyXmlTest do
+defmodule SecLatestFilingsRssFeedParserTest do
   use ExUnit.Case
 
-  import CandyXml
+  import SecLatestFilingsRssFeedParser
 
 #  test "parse!/1: parses RSS atom compliant XML" do
 #    xml = File.read!("test/fixtures/filings_atom_feed.xml")
-#    assert CandyXml.parse!(xml)
+#    assert SecLatestFilingsRssFeedParser.parse!(xml)
 #  end
 
 #  test "parse!/1: raises error on invalid XML" do

--- a/test/entry_test.exs
+++ b/test/entry_test.exs
@@ -1,7 +1,7 @@
-defmodule CandyXmlEntryTest do
+defmodule SecLatestFilingsRssFeedParserEntryTest do
   use ExUnit.Case
 
-  import CandyXml.Entry
+  import SecLatestFilingsRssFeedParser.Entry
 
   def entry_xml do
     """

--- a/test/feed_test.exs
+++ b/test/feed_test.exs
@@ -1,4 +1,4 @@
-defmodule CandyXmlFeedTest do
+defmodule SecLatestFilingsRssFeedParserFeedTest do
   use ExUnit.Case
 
   def feed_xml do
@@ -36,7 +36,7 @@ defmodule CandyXmlFeedTest do
   end
 
   test "parse/1" do
-    feed = feed_xml |> CandyXml.Feed.parse
+    feed = feed_xml |> SecLatestFilingsRssFeedParser.Feed.parse
     assert feed == %{
       updated: "2016-02-17T21:43:00-05:00",
       entries: [


### PR DESCRIPTION
Renaming the library from `CandyXml` to `SecLatestFilingsRssFeedParser` since this project is very specific rather than a broad XML parser.
