### PR TITLE
refactor with regex looking for 10 digits

### DIFF
--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -63,15 +63,10 @@ defmodule SecLatestFilingsRssFeedParser.Entry do
   end
 
   defp parse_cik_id(xml) do
-    regex = ~r/\(\d+\)/
+    regex = ~r/\d{10}/
     title = parse_title(xml)
 
     Regex.run(regex, title, capture: :first)
-    |> hd
-    |> String.split("(")
-    |> tl
-    |> hd
-    |> String.split(")")
     |> hd
   end
 end


### PR DESCRIPTION
Prior to this, there was a bit of wrangling to get a `cik` code out of the title of a feed entry. Since SEC `cik` codes are [10 digits](https://www.sec.gov/info/edgar/ednews/edrestr.htm) in length, this just uses a regex to grab a 10 digit number (which corresponds to the `cik` code) from the title.
