### PR TITLE
refactor tuple extraction of last item into helper

### DIFF
--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -1,5 +1,7 @@
 defmodule SecLatestFilingsRssFeedParser.Entry do
 
+  alias SecLatestFilingsRssFeedParser.Helpers
+
   defstruct [:title, :link, :summary, :updated_date, :rss_feed_id, :cik_id]
 
   def parse(xml) do
@@ -13,16 +15,11 @@ defmodule SecLatestFilingsRssFeedParser.Entry do
     }
   end
 
-  defp extract_title(tuple) do
-    {_, _, title} = tuple
-    title |> hd
-  end
-
   defp parse_title(xml) do
     xml
     |> Floki.find("title")
     |> hd
-    |> extract_title
+    |> Helpers.extract_last_item
   end
 
   defp parse_link(xml) do
@@ -38,28 +35,18 @@ defmodule SecLatestFilingsRssFeedParser.Entry do
     |> String.strip
   end
 
-  defp extract_updated_date(tuple) do
-    {_, _, updated} = tuple
-    updated |> hd
-  end
-
   defp parse_updated_date(xml) do
     xml
     |> Floki.find("updated")
     |> hd
-    |> extract_updated_date
-  end
-
-  defp extract_rss_feed_id(tuple) do
-    {_, _, rss_feed_id} = tuple
-    rss_feed_id |> hd
+    |> Helpers.extract_last_item
   end
 
   defp parse_rss_feed_id(xml) do
     xml
     |> Floki.find("id")
     |> hd
-    |> extract_rss_feed_id
+    |> Helpers.extract_last_item
   end
 
   defp parse_cik_id(xml) do

--- a/lib/feed.ex
+++ b/lib/feed.ex
@@ -1,5 +1,7 @@
 defmodule SecLatestFilingsRssFeedParser.Feed do
 
+  alias SecLatestFilingsRssFeedParser.Helpers
+
   defstruct [:entry]
 
   def parse(xml) do
@@ -14,15 +16,10 @@ defmodule SecLatestFilingsRssFeedParser.Feed do
     |> Enum.map(fn entry -> SecLatestFilingsRssFeedParser.Entry.parse(Floki.raw_html(entry)) end)
   end
 
-  defp extract_updated(tuple) do
-    {_, _, updated_date} = tuple
-    updated_date |> hd
-  end
-
   defp parse_updated(feed) do
     feed
     |> Floki.find("updated")
     |> hd
-    |> extract_updated
+    |> Helpers.extract_last_item
   end
 end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -1,0 +1,7 @@
+defmodule SecLatestFilingsRssFeedParser.Helpers do
+
+  def extract_last_item(tuple) do
+    {_, _, item} = tuple
+    item |> hd
+  end
+end

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -1,0 +1,11 @@
+defmodule SecLatestFilingsRssFeedParserHelpersTest do
+  use ExUnit.Case
+
+  import SecLatestFilingsRssFeedParser.Helpers
+
+  test "extract_last_item/1 returns last item of tuple" do
+    tuple = {[], "wut", ["thing"]}
+
+    assert extract_last_item(tuple) == "thing"
+  end
+end


### PR DESCRIPTION
This refactors a function that was used regularly but named differently in each instance into a helper in `lib/helpers.ex`
