### PR TITLE
replace cik_id with cik

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ The XML has a `feed`, which has many `entries`. Parsing the feed (`SecLatestFili
 
 ```elixir
 {:ok,
- %{entries: [%{cik_id: "0000050104",
+ %{entries: [%{cik: "0000050104",
       link: "http://www.sec.gov/Archives/edgar/data/50104/000005010416000055/0000050104-16-000055-index.htm",
       rss_feed_id: "urn:tag:sec.gov,2008:accession-number=0000050104-16-000055",
       summary: "Filed: 2016-02-25 AccNo: 0000050104-16-000055 Size: 23 MB",
       title: "10-K - TESORO CORP /NEW/ (0000050104) (Filer)",
       updated_date: "2016-02-25T17:29:49-05:00"
       category: "10-K"},
-    %{cik_id: "0000092230",
+    %{cik: "0000092230",
       link: "http://www.sec.gov/Archives/edgar/data/92230/000009223016000125/0000092230-16-000125-index.htm",
       rss_feed_id: "urn:tag:sec.gov,2008:accession-number=0000092230-16-000125",
       summary: "Filed: 2016-02-25 AccNo: 0000092230-16-000125 Size: 28 MB",
@@ -72,7 +72,7 @@ The XML has a `feed`, which has many `entries`. Parsing the feed (`SecLatestFili
     .
     .
     .
-    %{cik_id: "0001576169",
+    %{cik: "0001576169",
       link: "http://www.sec.gov/Archives/edgar/data/1576169/000119312516478532/0001193125-16-478532-index.htm",
       rss_feed_id: "urn:tag:sec.gov,2008:accession-number=0001193125-16-478532",
       summary: "Filed: 2016-02-25 AccNo: 0001193125-16-478532 Size: 7 MB",
@@ -82,7 +82,7 @@ The XML has a `feed`, which has many `entries`. Parsing the feed (`SecLatestFili
    updated: "2016-02-25T18:54:17-05:00"}}
 ```
 
-An entry's map contains a `cik_id` (the identifier the SEC uses for a company or security), a `link` to the filing, a `category` which represents the category of filing (10-K, 10-Q, 4, etc.), an `rss_feed_id` which represents a unique id of the entry, a `summary` which is a short summary of the document, a filing `title` and an `updated_date`. The feed is a map of those entries and an `updated` date of the feed.
+An entry's map contains a `cik` (the identifier the SEC uses for a company or security), a `link` to the filing, a `category` which represents the category of filing (10-K, 10-Q, 4, etc.), an `rss_feed_id` which represents a unique id of the entry, a `summary` which is a short summary of the document, a filing `title` and an `updated_date`. The feed is a map of those entries and an `updated` date of the feed.
 
 Be bold, use this tool to bring some sanity to parsing the SEC's XML feed and feel free to contribute!
 

--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -17,7 +17,7 @@ defmodule SecLatestFilingsRssFeedParser.Entry do
       summary: parse_summary(xml),
       updated_date: parse_updated_date(xml),
       rss_feed_id: parse_rss_feed_id(xml),
-      cik_id: parse_cik_id(xml),
+      cik: parse_cik(xml),
       category: parse_category(xml)
     }
   end
@@ -72,7 +72,7 @@ defmodule SecLatestFilingsRssFeedParser.Entry do
     id
   end
 
-  defp parse_cik_id(xml) do
+  defp parse_cik(xml) do
     regex = ~r/\d{10}/
     title = parse_title(xml)
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule SecLatestFilingsRssFeedParser.Mixfile do
 
   def project do
     [app: :sec_recent_filings_rss_feed_parser,
-     version: "0.0.4",
+     version: "0.0.5",
      elixir: "~> 1.2",
      description: description,
      build_embedded: Mix.env == :prod,

--- a/test/entry_test.exs
+++ b/test/entry_test.exs
@@ -18,9 +18,9 @@ defmodule SecLatestFilingsRssFeedParserEntryTest do
     """
   end
 
-  test "parses cik_id" do
+  test "parses cik" do
     entry = entry_xml |> parse
-    assert entry.cik_id == "0001121788"
+    assert entry.cik == "0001121788"
   end
 
   test "parses category" do

--- a/test/feed_test.exs
+++ b/test/feed_test.exs
@@ -46,7 +46,7 @@ defmodule SecLatestFilingsRssFeedParserFeedTest do
           summary: "Filed: 2016-02-16 AccNo: 0001069202-16-000014 Size: 24 MB",
           updated_date: "2016-02-16T11:52:50-05:00",
           rss_feed_id: "urn:tag:sec.gov,2008:accession-number=0001069202-16-000014",
-          cik_id: "0001069202",
+          cik: "0001069202",
           category: "10-K"
         },
         %{
@@ -55,7 +55,7 @@ defmodule SecLatestFilingsRssFeedParserFeedTest do
           summary: "Filed: 2016-02-16 AccNo: 0000764764-16-000111 Size: 20 MB",
           updated_date: "2016-02-16T11:24:30-05:00",
           rss_feed_id: "urn:tag:sec.gov,2008:accession-number=0000764764-16-000111",
-          cik_id: "0000764764",
+          cik: "0000764764",
           category: "10-K"
         }
       ]


### PR DESCRIPTION
This PR replaces `cik_id` with `cik` and updates the hex package version.
